### PR TITLE
Support setting lower bounds

### DIFF
--- a/custom_etkdg/molecule.py
+++ b/custom_etkdg/molecule.py
@@ -84,6 +84,9 @@ class RestrainedMolecule(Chem.Mol): #XXX name too generic? mention measurements 
 
     @distance_lower_bounds.setter
     def distance_lower_bounds(self, df):
+        self.RemoveAllConformers()
+        df = df.astype({"idx1" : np.uint, "idx2": np.uint, "distance" : float})
+        df.dropna(inplace = True) 
         self._distance_lower_bounds = df
 
     # def add_upper_bounds(self, df): #XXX add_bounds_equivalent_hydrogens = False):
@@ -144,7 +147,7 @@ class RestrainedMolecule(Chem.Mol): #XXX name too generic? mention measurements 
 
         self.upper_scaling = copy.deepcopy(scale_value)
 
-    def update_bmat(self):  #TODO only upperbound?
+    def update_bmat(self, include_lower_bounds=False):  #TODO only upperbound?
         """
         Load the user defined bounds matrix to the RestrainedMolecule object for conformer generation
         """
@@ -161,15 +164,24 @@ class RestrainedMolecule(Chem.Mol): #XXX name too generic? mention measurements 
             dist *= self.upper_scaling[index]
 
             a,b = int(a), int(b) #XXX awkard, even specified as int in dataframe still comes out as python floats
-            self.bmat[min((a,b)), max((a,b))] = dist #XXX only change if strink the bounds?
+            self.bmat[min((a,b)), max((a,b))] = dist #XXX only change if it shrinks the bounds?
+            # if the current lower bound is larger than the upper bound we're adding, shrink it:
             if self.bmat[max((a,b)), min((a,b))] > dist: 
                 self.bmat[max((a,b)), min((a,b))] = dist
 
-    # def triangular_smooth(self):
-    #     """
-    #     store bmat before and after smoothing 
-    #     identify max changes in distance bounds as some form of `sanity check`
-    #     """
+        if include_lower_bounds and self._distance_lower_bounds is not None:
+            for index, row in self._distance_lower_bounds.iterrows():
+                a, b, dist = row
+
+                dist *= self.lower_scaling[index]
+
+                a,b = int(a), int(b) #XXX awkard, even specified as int in dataframe still comes out as python floats
+                self.bmat[max((a,b)), min((a,b))] = dist #XXX only change if it shrinks the bounds?
+                # if the current upper bound is less than the lower bound we're adding, increase it:
+                if self.bmat[min((a,b)), max((a,b))] < dist: 
+                    self.bmat[min((a,b)), max((a,b))] = dist
+
+
         self.triangular_smoothed_bmat = copy.deepcopy(self.bmat) #FIXME split it out?
         DistanceGeometry.DoTriangleSmoothing(self.triangular_smoothed_bmat)
 

--- a/custom_etkdg/molecule.py
+++ b/custom_etkdg/molecule.py
@@ -544,6 +544,6 @@ class RestrainedMolecule(Chem.Mol): #XXX name too generic? mention measurements 
             setattr(newone, k, copy.deepcopy(v, memo))
         return newone
     
-    def __str__(self):
-        #TODO print the number of conformers!
-        raise NotImplementedError
+    # def __str__(self):
+    #     #TODO print the number of conformers!
+    #     raise NotImplementedError

--- a/custom_etkdg/noe.py
+++ b/custom_etkdg/noe.py
@@ -329,24 +329,17 @@ class NOE:
         if len(messages):
             logger.warning("\n".join(messages))
         
-        
-        
+        mol = RestrainedMolecule(mol)
         upper_df = pd.DataFrame.from_records(upper_df, columns = ["idx1", "idx2", "distance"])  #FIXME which distance specify?
         if not remember_chemical_equivalence:
             upper_df.sort_values(by = ["idx1", "idx2"], inplace = True, ignore_index = True) #XXX ordering is important when tracking chemical equivalence
+        mol.distance_upper_bounds = upper_df
         if lower_df:
             lower_df = pd.DataFrame.from_records(lower_df, columns = ["idx1", "idx2", "distance"])  #FIXME which distance specify?
             if not remember_chemical_equivalence:
                 lower_df.sort_values(by = ["idx1", "idx2"], inplace = True, ignore_index = True) #XXX ordering is important when tracking chemical equivalence
-        
-        mol = RestrainedMolecule(mol)
-        mol.distance_upper_bounds = upper_df
-        if lower_df is not []:
             mol.distance_lower_bounds = lower_df
-        else:
-            mol.distance_lower_bounds = None
         return mol
-
 
     def check_match_to_mol(self, mol):  
         """Check the matching between the NOE datatable and a molecule object, record statistics about the NOEs, e.g.:

--- a/custom_etkdg/noe.py
+++ b/custom_etkdg/noe.py
@@ -120,7 +120,7 @@ class NOE:
                     if line.startswith("assign"):  # data follows
                         line = line.split("!")[0]
                         line = line.replace("\t", " ")
-                        line = re.sub('\s+',' ',line)
+                        line = re.sub(r'\s+',' ',line)
                         res = xpl.findall(line)
                         assert len(res) == 7, f'Expected to get 7 entries from XPLOR line. Got {len(res)} from \"{line}\" on line {idx + 1}.'
                         data.append(res)
@@ -202,7 +202,7 @@ class NOE:
         isinstance(noe_df, pd.DataFrame)
 
         noe_df = noe_df.applymap(lambda s: s.upper() if type(s) == str else s)  # make strings uppercase
-        noe_df = noe_df.replace(["\*", "#"], "@", regex=True)  # convert from e.g. XPLOR format to GROMOS convention
+        noe_df = noe_df.replace([r"\*", "#"], "@", regex=True)  # convert from e.g. XPLOR format to GROMOS convention
         noe_df = noe_df.applymap(lambda s: 'H{}@'.format(s.replace('Q', '', 2)) if (type(s) == str and 'Q' in s) else s)
 
         return noe_df
@@ -212,7 +212,7 @@ class NOE:
         isinstance(noe_df, pd.DataFrame)
 
         noe_df = noe_df.applymap(lambda s: s.upper() if type(s) == str else s)  # make strings uppercase
-        noe_df = noe_df.replace(["\*", "#"], "@", regex=True)  # convert from e.g. XPLOR format to GROMOS convention
+        noe_df = noe_df.replace([r"\*", "#"], "@", regex=True)  # convert from e.g. XPLOR format to GROMOS convention
 
         # TODO: Manipulate distance restraints
         # divide @@ cases into two methyl groups

--- a/custom_etkdg/noe.py
+++ b/custom_etkdg/noe.py
@@ -38,27 +38,34 @@ class NOE:
     # def _constructor(self): #for inheriting pandas
     #     return NOE
 
-    def from_dataframe(self, df, which_cols = None):
-        """Create a NOE datatable from pandas DataFrame.
-        The minimum needed information to create the NOE:
+    def from_dataframe(self, df, which_cols = None, include_lower_bounds = False):
+        """Create a NOE datatable from pandas DataFrame. The minimum needed
+        information to create the NOE:
 
         cols = ['Residue_index_1', 'Residue_name_1', 'Residue_index_2',
                 'Residue_name_2', 'Upper_bound_[A]']
+
+        if include_lower_bounds is True, then the colum Lower_bound_[A] also
+        must be present
 
         Parameters
         ----------
         df : pd.DataFrame
-            
-        which_cols : list of indices, optional
-            The columns to obtain the information, by default None
+
+        which_cols : list of indices, optional The columns to obtain the
+            information, by default None
+
+        include_lower_bounds : use NOE lower bounds, by default False
         """
         cols = ['Residue_index_1', 'Residue_name_1', 'Residue_index_2',
                 'Residue_name_2', 'Upper_bound_[A]']
+        if include_lower_bounds:
+            cols.append('Lower_bound_[A]')
         
         if which_cols is None:
             df = df.loc[:, cols]
         else:
-            assert len(which_cols) == 5, ValueError("5 Columns are needed from input dataframe.")
+            assert len(which_cols) == len(cols), ValueError(f"{len(cols)} Columns are needed from input dataframe.")
             df = df.iloc[:, which_cols]
             df.columns = cols
             
@@ -67,6 +74,8 @@ class NOE:
         df['Residue_index_2'] = df['Residue_index_2'].astype(int)
         df['Residue_name_1'] = df['Residue_name_1'].astype(str)
         df['Residue_name_2'] = df['Residue_name_2'].astype(str)
+        if include_lower_bounds:
+            df['Lower_bound_[A]'] = df['Lower_bound_[A]'].astype(float)
 
         self.noe_table =  self.sanitize_xplor_noe(df)
 
@@ -290,7 +299,9 @@ class NOE:
 
         hydrogen_dict, mol_frame = self._mol2df(mol)
 
-        df = []
+        upper_df = []
+        lower_df = []
+
         messages = set([])
 
         if remember_chemical_equivalence:
@@ -302,8 +313,14 @@ class NOE:
 
             if len(idx1) > 0 and len(idx2) > 0:
                 val  = row["Upper_bound_[A]"] #TODO make this changeable
+                if "Lower_bound_[A]" in row:
+                    lower_val = row["Lower_bound_[A]"]
+                else:
+                    lower_val = None
                 for a,b in product(idx1, idx2):
-                    df.append((a,b,val))
+                    upper_df.append((a,b,val))
+                    if lower_val is not None:
+                        lower_df.append((a,b,lower_val))
                     if remember_chemical_equivalence:
                         self.chemical_equivalence_list.append(counter)
                 if remember_chemical_equivalence:
@@ -311,13 +328,25 @@ class NOE:
         
         if len(messages):
             logger.warning("\n".join(messages))
-        df = pd.DataFrame.from_records(df, columns = ["idx1", "idx2", "distance"])  #FIXME which distance specify?
-
+        
+        
+        
+        upper_df = pd.DataFrame.from_records(upper_df, columns = ["idx1", "idx2", "distance"])  #FIXME which distance specify?
         if not remember_chemical_equivalence:
-            df.sort_values(by = ["idx1", "idx2"], inplace = True, ignore_index = True) #XXX ordering is important when tracking chemical equivalence
+            upper_df.sort_values(by = ["idx1", "idx2"], inplace = True, ignore_index = True) #XXX ordering is important when tracking chemical equivalence
+        if lower_df:
+            lower_df = pd.DataFrame.from_records(lower_df, columns = ["idx1", "idx2", "distance"])  #FIXME which distance specify?
+            if not remember_chemical_equivalence:
+                lower_df.sort_values(by = ["idx1", "idx2"], inplace = True, ignore_index = True) #XXX ordering is important when tracking chemical equivalence
+        
         mol = RestrainedMolecule(mol)
-        mol.distance_upper_bounds = df
+        mol.distance_upper_bounds = upper_df
+        if lower_df is not []:
+            mol.distance_lower_bounds = lower_df
+        else:
+            mol.distance_lower_bounds = None
         return mol
+
 
     def check_match_to_mol(self, mol):  
         """Check the matching between the NOE datatable and a molecule object, record statistics about the NOEs, e.g.:
@@ -484,157 +513,157 @@ class NOE:
         raise NotImplementedError
 
 
-#deprecated
-def map_mol_with_noe(mol, df, verbose):
-    """
-    The goal is to make the atom names in the df to be
-    exactly the same as those in the mol naming
+# #deprecated
+# def map_mol_with_noe(mol, df, verbose):
+#     """
+#     The goal is to make the atom names in the df to be
+#     exactly the same as those in the mol naming
 
-    mol: must already have named hydrogens added!!!
-    """
-    mol_atom_names2noe_atom_names = {}
-    mol_atom_names2atom_index = {}
-    mol_resid_dict = {}
-    noe_resid_dict = {}
+#     mol: must already have named hydrogens added!!!
+#     """
+#     mol_atom_names2noe_atom_names = {}
+#     mol_atom_names2atom_index = {}
+#     mol_resid_dict = {}
+#     noe_resid_dict = {}
 
-    for idx, atm in enumerate(mol.GetAtoms()):  # find all H per residue in PDB mol
-        if atm.GetAtomicNum() == 1:  # only hydrogens are relevant for NOE mapping
-            key = atm.GetPDBResidueInfo().GetResidueNumber()
-            val = atm.GetPDBResidueInfo().GetName().strip()
-            mol_resid_dict.setdefault(key, {})[val] = 1  # no duplicate entries
+#     for idx, atm in enumerate(mol.GetAtoms()):  # find all H per residue in PDB mol
+#         if atm.GetAtomicNum() == 1:  # only hydrogens are relevant for NOE mapping
+#             key = atm.GetPDBResidueInfo().GetResidueNumber()
+#             val = atm.GetPDBResidueInfo().GetName().strip()
+#             mol_resid_dict.setdefault(key, {})[val] = 1  # no duplicate entries
 
-    for _, row in df.iterrows():  # find all H per residue in NOE representation
-        key = row["Residue_index_1"]
-        val = row["Residue_name_1"]
-        noe_resid_dict.setdefault(key, {})[val] = 1  # no duplicate entries
-        key = row["Residue_index_2"]
-        val = row["Residue_name_2"]
-        noe_resid_dict.setdefault(key, {})[val] = 1  # no duplicate entries
+#     for _, row in df.iterrows():  # find all H per residue in NOE representation
+#         key = row["Residue_index_1"]
+#         val = row["Residue_name_1"]
+#         noe_resid_dict.setdefault(key, {})[val] = 1  # no duplicate entries
+#         key = row["Residue_index_2"]
+#         val = row["Residue_name_2"]
+#         noe_resid_dict.setdefault(key, {})[val] = 1  # no duplicate entries
 
-    # matching and splitting of @ cases
-    exp_noe_names2mol_atom_names = {}
-    comb_noe_names2exp_noe_names = {}
-    print('#' * 80)
-    print('Atom mapping:')
-    print('#' * 80)
-    for resid in noe_resid_dict:
-        print(f'Residue: {resid}')
-        mol_atoms = list(mol_resid_dict.get(resid))
-        noe_atoms = list(noe_resid_dict.get(resid))
-        for atm in noe_atoms:
-            # print(atm, process.extract(atm, mol_atoms, scorer=fuzz.ratio))
-            # fit = process.extractOne(atm, mol_atoms, scorer=fuzz.ratio)
-            noe_key = (resid, atm)
-            if atm in mol_atoms:  # exact match found, just add it.
-                mol_val = (resid, atm)
-                # mol_atoms.remove(atm)  # already matched, no longer needed
-                exp_noe_names2mol_atom_names.setdefault(noe_key, {})[mol_val] = 1
-                comb_noe_names2exp_noe_names.setdefault(noe_key, {})[noe_key] = 1
-                print(f'NOE atom {atm} exactly mapped to PDB atom {atm}.')
-                added = True
-            elif '@' in atm:  # deal with multiplicities
-                strip_atm = atm.replace('@', '')
-                # print(atm, process.extract(strip_atm, mol_atoms, scorer=fuzz.ratio, limit=7))
-                fit = process.extract(strip_atm, mol_atoms, scorer=fuzz.ratio, limit=7)
-                try:
-                    best_score = fit[0][1]
-                except:
-                    continue
-                mult = 0
-                exp_noes = []
-                for score in fit:
-                    if (score[1] == best_score) and (strip_atm in score[0]):  # add all equivalently well matching names
-                        mult += 1
-                        noe_val = (resid, score[0])
-                        exp_noes.append(score[0])
-                        comb_noe_names2exp_noe_names.setdefault(noe_key, {})[noe_val] = 1
-                        exp_noe_names2mol_atom_names.setdefault(noe_val, {})[noe_val] = 1
-                        # mol_atoms.remove(score[0])
-                if mult is not 0:
-                    print(f'NOE atom {atm} expanded to {exp_noes} and mapped to corresponding PDB atoms.')
-                else:
-                    print(f'NOE atom {atm} could not be expanded and mapped to PDB atoms.')
-            else:
-                try:  # there might be no match
-                    mol_atm = process.extractOne(atm, mol_atoms, scorer=fuzz.ratio, score_cutoff=66)[0]
-                    mol_val = (resid, mol_atm)
-                    comb_noe_names2exp_noe_names.setdefault(noe_key, {})[noe_key] = 1
-                    exp_noe_names2mol_atom_names.setdefault(noe_key, {})[mol_val] = 1
-                    print(f'NOE atom {atm} approximately mapped to PDB atom {mol_atm}.')
-                except:
-                    print(f'Unaccounted NOE atom: {atm}.')
-                # print(mult)
-            # exp_noe_names2mol_atom_names
-        #print(f'Remaining PDB atoms: {mol_atoms}')
-        print('#' * 80)
+#     # matching and splitting of @ cases
+#     exp_noe_names2mol_atom_names = {}
+#     comb_noe_names2exp_noe_names = {}
+#     print('#' * 80)
+#     print('Atom mapping:')
+#     print('#' * 80)
+#     for resid in noe_resid_dict:
+#         print(f'Residue: {resid}')
+#         mol_atoms = list(mol_resid_dict.get(resid))
+#         noe_atoms = list(noe_resid_dict.get(resid))
+#         for atm in noe_atoms:
+#             # print(atm, process.extract(atm, mol_atoms, scorer=fuzz.ratio))
+#             # fit = process.extractOne(atm, mol_atoms, scorer=fuzz.ratio)
+#             noe_key = (resid, atm)
+#             if atm in mol_atoms:  # exact match found, just add it.
+#                 mol_val = (resid, atm)
+#                 # mol_atoms.remove(atm)  # already matched, no longer needed
+#                 exp_noe_names2mol_atom_names.setdefault(noe_key, {})[mol_val] = 1
+#                 comb_noe_names2exp_noe_names.setdefault(noe_key, {})[noe_key] = 1
+#                 print(f'NOE atom {atm} exactly mapped to PDB atom {atm}.')
+#                 added = True
+#             elif '@' in atm:  # deal with multiplicities
+#                 strip_atm = atm.replace('@', '')
+#                 # print(atm, process.extract(strip_atm, mol_atoms, scorer=fuzz.ratio, limit=7))
+#                 fit = process.extract(strip_atm, mol_atoms, scorer=fuzz.ratio, limit=7)
+#                 try:
+#                     best_score = fit[0][1]
+#                 except:
+#                     continue
+#                 mult = 0
+#                 exp_noes = []
+#                 for score in fit:
+#                     if (score[1] == best_score) and (strip_atm in score[0]):  # add all equivalently well matching names
+#                         mult += 1
+#                         noe_val = (resid, score[0])
+#                         exp_noes.append(score[0])
+#                         comb_noe_names2exp_noe_names.setdefault(noe_key, {})[noe_val] = 1
+#                         exp_noe_names2mol_atom_names.setdefault(noe_val, {})[noe_val] = 1
+#                         # mol_atoms.remove(score[0])
+#                 if mult is not 0:
+#                     print(f'NOE atom {atm} expanded to {exp_noes} and mapped to corresponding PDB atoms.')
+#                 else:
+#                     print(f'NOE atom {atm} could not be expanded and mapped to PDB atoms.')
+#             else:
+#                 try:  # there might be no match
+#                     mol_atm = process.extractOne(atm, mol_atoms, scorer=fuzz.ratio, score_cutoff=66)[0]
+#                     mol_val = (resid, mol_atm)
+#                     comb_noe_names2exp_noe_names.setdefault(noe_key, {})[noe_key] = 1
+#                     exp_noe_names2mol_atom_names.setdefault(noe_key, {})[mol_val] = 1
+#                     print(f'NOE atom {atm} approximately mapped to PDB atom {mol_atm}.')
+#                 except:
+#                     print(f'Unaccounted NOE atom: {atm}.')
+#                 # print(mult)
+#             # exp_noe_names2mol_atom_names
+#         #print(f'Remaining PDB atoms: {mol_atoms}')
+#         print('#' * 80)
 
-    for idx, atm in enumerate(mol.GetAtoms()):
-        if atm.GetAtomicNum() != 1:  # currently only needs the hydrogen
-            continue
-        key = (
-            int(format(atm.GetPDBResidueInfo().GetResidueNumber())),
-            "{}".format(atm.GetPDBResidueInfo().GetName().strip()))
-        mol_atom_names2noe_atom_names[key] = set()
-        mol_atom_names2atom_index.setdefault(key, []).append(idx)
+#     for idx, atm in enumerate(mol.GetAtoms()):
+#         if atm.GetAtomicNum() != 1:  # currently only needs the hydrogen
+#             continue
+#         key = (
+#             int(format(atm.GetPDBResidueInfo().GetResidueNumber())),
+#             "{}".format(atm.GetPDBResidueInfo().GetName().strip()))
+#         mol_atom_names2noe_atom_names[key] = set()
+#         mol_atom_names2atom_index.setdefault(key, []).append(idx)
 
-    noe_atom_pair2upper_distance = dict()
-    for _, row in df.iterrows():
-        # achieve canonical ordering, so each tuple only needs to be added once
-        tup1 = (int(row["Residue_index_1"]), "{}".format(row["Residue_name_1"]))
-        tup2 = (int(row["Residue_index_2"]), "{}".format(row["Residue_name_2"]))
-        key = (int(tup1[0]), key)  # add back the index
-        tup_list = [tup1, tup2]
-        tups = sorted(tup_list, key=lambda element: (element[0], element[1]))
+#     noe_atom_pair2upper_distance = dict()
+#     for _, row in df.iterrows():
+#         # achieve canonical ordering, so each tuple only needs to be added once
+#         tup1 = (int(row["Residue_index_1"]), "{}".format(row["Residue_name_1"]))
+#         tup2 = (int(row["Residue_index_2"]), "{}".format(row["Residue_name_2"]))
+#         key = (int(tup1[0]), key)  # add back the index
+#         tup_list = [tup1, tup2]
+#         tups = sorted(tup_list, key=lambda element: (element[0], element[1]))
 
-        # only keep the most restrictive value
-        try:
-            old_val = noe_atom_pair2upper_distance[(tups[0], tups[1])]
-            noe_atom_pair2upper_distance[(tups[0], tups[1])] = min(old_val, row["Upper_bound_[A]"])
-        except KeyError:
-            noe_atom_pair2upper_distance[(tups[0], tups[1])] = row["Upper_bound_[A]"]
+#         # only keep the most restrictive value
+#         try:
+#             old_val = noe_atom_pair2upper_distance[(tups[0], tups[1])]
+#             noe_atom_pair2upper_distance[(tups[0], tups[1])] = min(old_val, row["Upper_bound_[A]"])
+#         except KeyError:
+#             noe_atom_pair2upper_distance[(tups[0], tups[1])] = row["Upper_bound_[A]"]
 
-    # in this case usually go and change the NOE dataframe,
-    # because the atom names in the pdb file can actually have meaning when running MD
-    trigger = False
-    for key, val in mol_atom_names2noe_atom_names.items():
-        if len(val) > 1:
-            print("Non-unique mapping between PDB atom {} and NOE atoms {}.".format(key, val))
-            pick = query_yes_no("Pick most probable NOE atom {} (yes) or exit (no)?"
-                                .format(difflib.get_close_matches(key[1], [j[1] for j in val], 1, 0.5)[0]))
-            if pick:
-                val = difflib.get_close_matches(key[1], [j[1] for j in val], 1, 0.5)[0]
-                val = {(key[0], val)}  # add back the index
-                # mol_atom_names2noe_atom_names.pop(key, None) # remove non-unique
-                mol_atom_names2noe_atom_names[key] = val  # re-add most probable
-                print("Chosen mapping: {}   {}".format(key, val))
-                exp_noe_names2mol_atom_names[min(val)] = key
-            else:
-                raise ValueError("Non Unique Mapping(s)")
+#     # in this case usually go and change the NOE dataframe,
+#     # because the atom names in the pdb file can actually have meaning when running MD
+#     trigger = False
+#     for key, val in mol_atom_names2noe_atom_names.items():
+#         if len(val) > 1:
+#             print("Non-unique mapping between PDB atom {} and NOE atoms {}.".format(key, val))
+#             pick = query_yes_no("Pick most probable NOE atom {} (yes) or exit (no)?"
+#                                 .format(difflib.get_close_matches(key[1], [j[1] for j in val], 1, 0.5)[0]))
+#             if pick:
+#                 val = difflib.get_close_matches(key[1], [j[1] for j in val], 1, 0.5)[0]
+#                 val = {(key[0], val)}  # add back the index
+#                 # mol_atom_names2noe_atom_names.pop(key, None) # remove non-unique
+#                 mol_atom_names2noe_atom_names[key] = val  # re-add most probable
+#                 print("Chosen mapping: {}   {}".format(key, val))
+#                 exp_noe_names2mol_atom_names[min(val)] = key
+#             else:
+#                 raise ValueError("Non Unique Mapping(s)")
 
-    if trigger: raise ValueError("Non Unique Mapping(s)")
+#     if trigger: raise ValueError("Non Unique Mapping(s)")
 
-    if verbose:
-        print('#' * 80)
-        print("Summary of chosen matches:")
-        resid = 0
-        for key, val in mol_atom_names2noe_atom_names.items():
-            if int(key[0]) is not resid:
-                print('#' * 80)
-                print(f"Residue {key[0]}")
-                resid = int(key[0])
+#     if verbose:
+#         print('#' * 80)
+#         print("Summary of chosen matches:")
+#         resid = 0
+#         for key, val in mol_atom_names2noe_atom_names.items():
+#             if int(key[0]) is not resid:
+#                 print('#' * 80)
+#                 print(f"Residue {key[0]}")
+#                 resid = int(key[0])
 
-            print(f"PDB name {key} is matched to NOE name {val}.")
+#             print(f"PDB name {key} is matched to NOE name {val}.")
 
-        print('#' * 80)
-        print('#' * 80)
+#         print('#' * 80)
+#         print('#' * 80)
 
-        for key, val in mol_atom_names2noe_atom_names.items():
-            # if int(key[0]) is not resid:
-            #    print('#' * 80)
-            #    print(f"Residue {key[0]}")
-            #    resid = int(key[0])
+#         for key, val in mol_atom_names2noe_atom_names.items():
+#             # if int(key[0]) is not resid:
+#             #    print('#' * 80)
+#             #    print(f"Residue {key[0]}")
+#             #    resid = int(key[0])
 
-            print(f"NOE name {key} is matched to PDB name {val}.")
+#             print(f"NOE name {key} is matched to PDB name {val}.")
 
-    return mol_atom_names2atom_index, comb_noe_names2exp_noe_names, exp_noe_names2mol_atom_names, \
-           noe_atom_pair2upper_distance, df
+#     return mol_atom_names2atom_index, comb_noe_names2exp_noe_names, exp_noe_names2mol_atom_names, \
+#            noe_atom_pair2upper_distance, df

--- a/custom_etkdg/simulation.py
+++ b/custom_etkdg/simulation.py
@@ -1,3 +1,6 @@
+import logging
+logger = logging.getLogger(__name__)
+
 import parmed
 import mdtraj as md
 from mdtraj.reporters import HDF5Reporter
@@ -8,7 +11,11 @@ from simtk import unit
 from simtk.openmm import LangevinIntegrator, CustomBondForce, AndersenThermostat, MonteCarloBarostat, VerletIntegrator, Platform
 from simtk.openmm.app import Simulation, HBonds, NoCutoff, AllBonds, PME
 
-import mlddec
+try:
+    import mlddec
+except ImportError:
+    logger.warning("could not import mlddec package. Any calls to mlddec will fail")
+    mlddec = None
 from rdkit.Geometry import Point3D
 from rdkit import Chem
 from rdkit.Chem import AllChem

--- a/custom_etkdg/tests/test_lower_bounds.py
+++ b/custom_etkdg/tests/test_lower_bounds.py
@@ -1,0 +1,38 @@
+import pytest
+
+from custom_etkdg.utils import *
+from custom_etkdg.mol_ops import *
+from custom_etkdg.noe import NOE
+from rdkit import Chem
+import logging
+
+logging.getLogger().setLevel(logging.INFO)
+
+smiles = open(get_data_file_path("6BF3/6bf3.smi"), "r").readlines()[0].strip()
+mol = mol_from_smiles_pdb(smiles, get_data_file_path("6BF3/6bf3.pdb"), infer_names = True)
+
+
+noe = NOE()
+noe.from_explor(get_data_file_path("6BF3/6bf3.mr"))
+
+
+resmol = noe.add_noe_to_mol(mol)
+resmol.update_bmat()
+assert resmol.bmat[25][86]==4.7
+assert resmol.bmat[86][25]==2.4
+resmol.scale_upper_distances(1.4)
+resmol.update_bmat() #!!!! always need to update the bmat after changing the scaling
+assert resmol.bmat[25,86]==4.7*1.4
+assert resmol.bmat[86,25]==2.4
+
+resmol = noe.add_noe_to_mol(mol)
+resmol.update_bmat(include_lower_bounds=True)
+assert resmol.bmat[25,86]==4.7
+assert resmol.bmat[86,25]==2.3
+resmol.scale_lower_distances(1.4)
+resmol.update_bmat(include_lower_bounds=True) #!!!! always need to update the bmat after changing the scaling
+assert resmol.bmat[25,86]==4.7
+assert resmol.bmat[86,25]==2.3*1.4
+
+
+

--- a/custom_etkdg/tests/test_lower_bounds.py
+++ b/custom_etkdg/tests/test_lower_bounds.py
@@ -8,31 +8,43 @@ import logging
 
 logging.getLogger().setLevel(logging.INFO)
 
-smiles = open(get_data_file_path("6BF3/6bf3.smi"), "r").readlines()[0].strip()
-mol = mol_from_smiles_pdb(smiles, get_data_file_path("6BF3/6bf3.pdb"), infer_names = True)
+def test_lower_bounds():
+    smiles = open(get_data_file_path("6BF3/6bf3.smi"), "r").readlines()[0].strip()
+    mol = mol_from_smiles_pdb(smiles, get_data_file_path("6BF3/6bf3.pdb"), infer_names = True)
 
 
-noe = NOE()
-noe.from_explor(get_data_file_path("6BF3/6bf3.mr"))
+    noe = NOE()
+    noe.from_explor(get_data_file_path("6BF3/6bf3.mr"))
 
 
-resmol = noe.add_noe_to_mol(mol)
-resmol.update_bmat()
-assert resmol.bmat[25][86]==4.7
-assert resmol.bmat[86][25]==2.4
-resmol.scale_upper_distances(1.4)
-resmol.update_bmat() #!!!! always need to update the bmat after changing the scaling
-assert resmol.bmat[25,86]==4.7*1.4
-assert resmol.bmat[86,25]==2.4
+    resmol = noe.add_noe_to_mol(mol)
+    resmol.update_bmat()
+    assert resmol.bmat[25][86]==4.7
+    assert resmol.bmat[86][25]==2.4
+    resmol.scale_upper_distances(1.4)
+    resmol.update_bmat() #!!!! always need to update the bmat after changing the scaling
+    assert resmol.bmat[25,86]==4.7*1.4
+    assert resmol.bmat[86,25]==2.4
 
-resmol = noe.add_noe_to_mol(mol)
-resmol.update_bmat(include_lower_bounds=True)
-assert resmol.bmat[25,86]==4.7
-assert resmol.bmat[86,25]==2.3
-resmol.scale_lower_distances(1.4)
-resmol.update_bmat(include_lower_bounds=True) #!!!! always need to update the bmat after changing the scaling
-assert resmol.bmat[25,86]==4.7
-assert resmol.bmat[86,25]==2.3*1.4
+    resmol = noe.add_noe_to_mol(mol)
+    resmol.update_bmat(include_lower_bounds=True)
+    assert resmol.bmat[25,86]==4.7
+    assert resmol.bmat[86,25]==2.3
+    resmol.scale_lower_distances(1.4)
+    resmol.update_bmat(include_lower_bounds=True) #!!!! always need to update the bmat after changing the scaling
+    assert resmol.bmat[25,86]==4.7
+    assert resmol.bmat[86,25]==2.3*1.4
+
+def test_no_lower_bounds():
+    smiles = open(get_data_file_path("6HVC/6hvc.smi"), "r").readlines()[0].strip()
+    mol = mol_from_smiles_pdb(smiles, get_data_file_path("6HVC/6hvc.pdb"), infer_names = True)
 
 
+    noe = NOE()
+    noe.from_explor(get_data_file_path("6HVC/6hvc.mr"))
 
+
+    resmol = noe.add_noe_to_mol(mol)
+    resmol.update_bmat()
+    assert resmol.bmat[25][86]==pytest.approx(13.46,abs=0.01)
+    assert resmol.bmat[86][25]==pytest.approx(2.90,abs=0.01)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Optional include package data to ship with your package
     # Comment out this line to prevent the files from being packaged with your software
     # Extend/modify the list to include/exclude other items as need be
-    package_data={'custom_etkdg': ["data/*.dat"]
+    package_data={'custom_etkdg': ["data/6VY8/*"]
                   },
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     # Optional include package data to ship with your package
     # Comment out this line to prevent the files from being packaged with your software
     # Extend/modify the list to include/exclude other items as need be
-    package_data={'custom_etkdg': ["data/6VY8/*"]
+    package_data={'custom_etkdg': ["data/6VY8/*","data/6HVC/*", "data/6BF3/*"]
                   },
 
     # Additional entries you may want simply uncomment the lines you want and fill in the data


### PR DESCRIPTION
Now that we know that lower bounds from NOE can be reliable it makes sense to enable support for them in customETKDG.
This PR does that, but makes the lower bounds optional and does not enable them by default.

The incantation to include lower bounds is to pass `include_lower_bounds=True` to `update_bmat()`:
```
resmol = noe.add_noe_to_mol(mol)
resmol.update_bmat(include_lower_bounds=True)
```

The PR also includes a small amount of code cleanup and some tweaks to the `setup.py` file to ensure that the test data files and those used in the demo notebooks are actually installed.
